### PR TITLE
Additional profile items: dynamic CardView from server JSON

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/example/cleanarchitecturetest/presentation/profile/AdditionalProfileItemsBinder.kt
+++ b/app/src/main/java/com/example/cleanarchitecturetest/presentation/profile/AdditionalProfileItemsBinder.kt
@@ -1,0 +1,85 @@
+package com.example.cleanarchitecturetest.presentation.profile
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.cardview.widget.CardView
+import com.example.cleanarchitecturetest.data.profile.AdditionalProfileItem
+import com.example.cleanarchitecturetest.data.profile.AdditionalProfileItemsParser
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+
+/**
+ * Binds [CardView] + [LinearLayout] container to nested additional profile rows.
+ * Opens WebView via [openWebView]; in Aparu use `WebViewActivity` with `title` and `url` extras.
+ *
+ * **Integrate in `profile2.xml`:** after `notificationsAndSoundLayout`, before `passengerReportsCardView`:
+ * `<include layout="@layout/profile_additional_items_card" />`
+ *
+ * **In `ProfileActivity2`:** after `findViewById` / view binding, call
+ * [bindFromProfileJsonString] with `session.getDriverProfile()` (or your Gson model’s JSON) and
+ * `session.isDriver()`.
+ */
+object AdditionalProfileItemsBinder {
+
+    fun bindFromProfileJsonString(
+        cardView: CardView,
+        container: LinearLayout,
+        profileJson: String?,
+        isDriver: Boolean,
+        openWebView: (context: Context, title: String, url: String) -> Unit,
+    ) {
+        val root = try {
+            if (profileJson.isNullOrBlank()) null
+            else JsonParser.parseString(profileJson).takeIf { it.isJsonObject }?.asJsonObject
+        } catch (_: Exception) {
+            null
+        }
+        bind(cardView, container, root, isDriver, openWebView)
+    }
+
+    fun bind(
+        cardView: CardView,
+        container: LinearLayout,
+        profile: JsonObject?,
+        isDriver: Boolean,
+        openWebView: (context: Context, title: String, url: String) -> Unit,
+    ) {
+        val element = AdditionalProfileItemsParser.elementFromProfileJson(profile, isDriver)
+        val sections = AdditionalProfileItemsParser.parse(element)
+        val visible = AdditionalProfileItemsParser.hasDisplayableItems(sections)
+        cardView.visibility = if (visible) View.VISIBLE else View.GONE
+        container.removeAllViews()
+        if (!visible || sections == null) return
+
+        val inflater = LayoutInflater.from(container.context)
+        var isFirstSection = true
+        for (items in sections) {
+            if (items.isEmpty()) continue
+            if (!isFirstSection) {
+                inflater.inflate(com.example.cleanarchitecturetest.R.layout.item_additional_profile_divider, container, true)
+            }
+            isFirstSection = false
+            for (item in items) {
+                addRow(inflater, container, item, openWebView)
+            }
+        }
+    }
+
+    private fun addRow(
+        inflater: LayoutInflater,
+        container: LinearLayout,
+        item: AdditionalProfileItem,
+        openWebView: (context: Context, title: String, url: String) -> Unit,
+    ) {
+        val row = inflater.inflate(com.example.cleanarchitecturetest.R.layout.item_additional_profile_row, container, false)
+        val titleView = row.findViewById<TextView>(com.example.cleanarchitecturetest.R.id.additionalProfileRowTitle)
+        titleView.text = item.title
+        row.setOnClickListener {
+            openWebView(container.context, item.webTitle, item.link)
+        }
+        container.addView(row)
+    }
+}

--- a/app/src/main/res/layout/item_additional_profile_divider.xml
+++ b/app/src/main/res/layout/item_additional_profile_divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="8dp"
+    android:background="@android:color/transparent" />

--- a/app/src/main/res/layout/item_additional_profile_row.xml
+++ b/app/src/main/res/layout/item_additional_profile_row.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="15dp">
+
+        <TextView
+            android:id="@+id/additionalProfileRowTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            android:textSize="16sp" />
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="@color/gray_light_bg" />
+</LinearLayout>

--- a/app/src/main/res/layout/profile_additional_items_card.xml
+++ b/app/src/main/res/layout/profile_additional_items_card.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Include after notificationsAndSoundLayout (before passengerReportsCardView / menu card). Default gone until profile JSON has items. -->
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/additionalProfileItemsCardView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="10dp"
+    android:visibility="gone"
+    app:cardElevation="2dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="15dp"
+            android:layout_marginTop="15dp"
+            android:layout_marginRight="15dp"
+            android:text="@string/additional_profile_items"
+            android:textColor="@color/blue"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:id="@+id/additionalProfileItemsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp" />
+    </LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="gray_light_bg">#FFE0E0E0</color>
+    <color name="blue">#FF2196F3</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Clean Architecture Test</string>
+    <string name="additional_profile_items">Additional</string>
 </resources>

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -31,6 +31,7 @@ android {
 
 dependencies {
     implementation project(path: ':domain')
+    implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
 }

--- a/data/src/main/java/com/example/cleanarchitecturetest/data/profile/AdditionalProfileItem.kt
+++ b/data/src/main/java/com/example/cleanarchitecturetest/data/profile/AdditionalProfileItem.kt
@@ -1,0 +1,10 @@
+package com.example.cleanarchitecturetest.data.profile
+
+/**
+ * One row in [AdditionalProfileItemsParser]: list title in the profile, WebView toolbar title, URL.
+ */
+data class AdditionalProfileItem(
+    val title: String,
+    val webTitle: String,
+    val link: String,
+)

--- a/data/src/main/java/com/example/cleanarchitecturetest/data/profile/AdditionalProfileItemsParser.kt
+++ b/data/src/main/java/com/example/cleanarchitecturetest/data/profile/AdditionalProfileItemsParser.kt
@@ -1,0 +1,76 @@
+package com.example.cleanarchitecturetest.data.profile
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+
+/**
+ * Parses server payload shaped as `[[{title, web_title, link}, ...], [], ...]`.
+ * Empty inner arrays mean a skipped section (no rows for that index).
+ *
+ * Wire into profile JSON as `psg_additional_profile_items` / `drv_additional_profile_items`
+ * (or legacy `psg_additional_items` / `driver_additional_items`) on your profile model.
+ */
+object AdditionalProfileItemsParser {
+
+    private val DRIVER_KEYS = listOf("drv_additional_profile_items", "driver_additional_items")
+    private val PASSENGER_KEYS = listOf("psg_additional_profile_items", "psg_additional_items")
+
+    /**
+     * Picks the first present non-null JSON array from [profile] for driver vs passenger.
+     */
+    fun elementFromProfileJson(profile: JsonObject?, isDriver: Boolean): JsonElement? {
+        if (profile == null) return null
+        val keys = if (isDriver) DRIVER_KEYS else PASSENGER_KEYS
+        for (key in keys) {
+            if (!profile.has(key)) continue
+            val el = profile.get(key) ?: continue
+            if (el.isJsonNull) continue
+            if (el.isJsonArray) return el
+        }
+        return null
+    }
+
+    fun parse(element: JsonElement?): List<List<AdditionalProfileItem>>? {
+        if (element == null || element.isJsonNull) return null
+        if (!element.isJsonArray) return null
+        val outer = element.asJsonArray
+        if (outer.size() == 0) return emptyList()
+
+        val result = ArrayList<List<AdditionalProfileItem>>(outer.size())
+        for (sectionEl in outer) {
+            if (!sectionEl.isJsonArray) {
+                result.add(emptyList())
+                continue
+            }
+            val inner = sectionEl.asJsonArray
+            val items = ArrayList<AdditionalProfileItem>()
+            for (itemEl in inner) {
+                if (!itemEl.isJsonObject) continue
+                val o = itemEl.asJsonObject
+                val title = o.stringOrNull("title") ?: continue
+                val webTitle = o.stringOrNull("web_title") ?: title
+                val link = o.stringOrNull("link") ?: continue
+                if (link.isBlank()) continue
+                items.add(AdditionalProfileItem(title = title, webTitle = webTitle, link = link))
+            }
+            result.add(items)
+        }
+        return result
+    }
+
+    fun hasDisplayableItems(sections: List<List<AdditionalProfileItem>>?): Boolean {
+        if (sections == null) return false
+        return sections.any { it.isNotEmpty() }
+    }
+
+    private fun JsonObject.stringOrNull(name: String): String? {
+        if (!has(name)) return null
+        val el = get(name) ?: return null
+        if (el.isJsonNull || !el.isJsonPrimitive) return null
+        return try {
+            el.asString.takeIf { it.isNotBlank() }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/data/src/test/java/com/example/cleanarchitecturetest/data/profile/AdditionalProfileItemsParserTest.kt
+++ b/data/src/test/java/com/example/cleanarchitecturetest/data/profile/AdditionalProfileItemsParserTest.kt
@@ -1,0 +1,47 @@
+package com.example.cleanarchitecturetest.data.profile
+
+import com.google.gson.JsonParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdditionalProfileItemsParserTest {
+
+    @Test
+    fun parse_skipsEmptySections_andReadsItems() {
+        val json = """
+            [[{"title":"A","web_title":"WA","link":"https://a"}],
+             [],
+             [{"title":"B","web_title":"WB","link":"https://b"}]]
+        """.trimIndent()
+        val el = JsonParser.parseString(json)
+        val sections = AdditionalProfileItemsParser.parse(el)!!
+        assertEquals(3, sections.size)
+        assertEquals(1, sections[0].size)
+        assertEquals("A", sections[0][0].title)
+        assertTrue(sections[1].isEmpty())
+        assertEquals("B", sections[2][0].title)
+        assertTrue(AdditionalProfileItemsParser.hasDisplayableItems(sections))
+    }
+
+    @Test
+    fun elementFromProfileJson_prefersNamedKeys() {
+        val profile = JsonParser.parseString(
+            """{"drv_additional_profile_items":[[{"title":"D","link":"https://d"}]],"driver_additional_items":[]}"""
+        ).asJsonObject
+        val el = AdditionalProfileItemsParser.elementFromProfileJson(profile, isDriver = true)
+        assertNotNull(el)
+        val sections = AdditionalProfileItemsParser.parse(el!!)!!
+        assertEquals(1, sections[0].size)
+        assertEquals("D", sections[0][0].title)
+    }
+
+    @Test
+    fun hasDisplayableItems_falseWhenAllSectionsEmpty() {
+        val json = "[[],[]]"
+        val sections = AdditionalProfileItemsParser.parse(JsonParser.parseString(json))!!
+        assertFalse(AdditionalProfileItemsParser.hasDisplayableItems(sections))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds reusable pieces for the profile screen pattern you described: server returns nested arrays `[[{title, web_title, link}, ...], [], ...]` where empty inner arrays skip a section. The CardView is shown only when at least one section has items; otherwise it uses `View.GONE`.

## What changed

- **`AdditionalProfileItemsParser`** (`data` module): reads `psg_additional_profile_items` / `drv_additional_profile_items`, with fallbacks to `psg_additional_items` / `driver_additional_items`. Parses nested JSON; `hasDisplayableItems` drives visibility.
- **Layouts**: `profile_additional_items_card.xml` (include after notifications block), `item_additional_profile_row.xml`, `item_additional_profile_divider.xml` (spacing between non-empty sections).
- **`AdditionalProfileItemsBinder`** (`app` module): inflates rows, wires clicks to a WebView callback (plug in your `WebViewActivity` in Aparu).
- **Tests**: `AdditionalProfileItemsParserTest` for parsing and empty sections.
- **Dependencies**: Gson on `:data` and `:app`; CardView on `:app`.

## Integrating in Aparu `ProfileActivity2`

1. Copy or merge the parser/binder/layouts (or depend on a shared module if you extract one).
2. In `profile2.xml`, after `notificationsAndSoundLayout` and before `passengerReportsCardView`:

   `<include layout="@layout/profile_additional_items_card" />`

3. In `initViews()` / after profile load:

   ```kotlin
   val card = findViewById<CardView>(R.id.additionalProfileItemsCardView)
   val container = findViewById<LinearLayout>(R.id.additionalProfileItemsContainer)
   AdditionalProfileItemsBinder.bindFromProfileJsonString(
       card, container, session.getDriverProfile(), session.isDriver()
   ) { ctx, title, url ->
       startActivity(Intent(ctx, WebViewActivity::class.java).apply {
           putExtra("title", title)
           putExtra("url", url)
       })
   }
   ```

   Call the same binder from `updateProfileData()` and inside the `getDriverProfile` success path after `session.setDriverProfile(...)`.

4. On **`DriverProfileModel`**, add nullable fields matching server names (`psg_additional_profile_items`, `drv_additional_profile_items`) typed as `JsonArray` or `List<List<...>>` if you prefer typed Gson; the binder can also consume raw profile JSON from session as above.

## Verification

Gradle build was not run in the agent environment (no Android SDK). Run `./gradlew :data:testDebugUnitTest :app:assembleDebug` locally with JDK 17 and a configured SDK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fd6f9b3-4d9a-45ff-936e-94cd33e27a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fd6f9b3-4d9a-45ff-936e-94cd33e27a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

